### PR TITLE
add round-trip serde for prc/pdb and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 
 [package]
 resolver = "2"
-edition = "2018"
+edition = "2021"
 name = "palmrs"
 version = "0.1.0-dev.1"
 license = "MIT OR Apache-2.0"

--- a/palmrs-database/src/info/mod.rs
+++ b/palmrs-database/src/info/mod.rs
@@ -9,11 +9,14 @@ pub mod category;
 
 /// Helper trait for decoding & encoding "extra data" records (app info / sort info)
 pub trait ExtraInfoRecord: Sized + Debug {
+	/// Size in bytes (packed) which the ExtraInfoRecord occupies in the pdb/prc
+	const SIZE: usize;
+
 	/// Read the record header from the given byte array
 	fn from_bytes(hdr: &DatabaseHeader, data: &[u8], pos: usize) -> Result<Self, io::Error>;
 
 	/// Write the record header to a new `Vec<u8>`
-	fn write_bytes(&self) -> Result<Vec<u8>, io::Error>;
+	fn to_bytes(&self) -> Result<Vec<u8>, io::Error>;
 
 	/// Whether this ExtraInfoRecord contains no data
 	fn data_empty(&self) -> bool;
@@ -28,11 +31,13 @@ pub trait ExtraInfoRecord: Sized + Debug {
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct NullExtraInfo;
 impl ExtraInfoRecord for NullExtraInfo {
+	const SIZE: usize = 0;
+
 	fn from_bytes(_hdr: &DatabaseHeader, _data: &[u8], _pos: usize) -> Result<Self, io::Error> {
 		Ok(Self)
 	}
 
-	fn write_bytes(&self) -> Result<Vec<u8>, io::Error> {
+	fn to_bytes(&self) -> Result<Vec<u8>, io::Error> {
 		Ok(Vec::new())
 	}
 

--- a/palmrs-database/src/record/mod.rs
+++ b/palmrs-database/src/record/mod.rs
@@ -20,7 +20,7 @@ pub trait DatabaseRecord: Sized + Debug {
 	fn from_bytes(hdr: &DatabaseHeader, data: &[u8], pos: usize) -> Result<Self, io::Error>;
 
 	/// Write the record header to a new `Vec<u8>`
-	fn write_bytes(&self) -> Result<Vec<u8>, io::Error>;
+	fn to_bytes(&self) -> Result<Vec<u8>, io::Error>;
 
 	/// Return the record's name, if known
 	fn name_str(&self) -> Option<&str>;

--- a/palmrs-database/tests/format_pdb_palmdoc.rs
+++ b/palmrs-database/tests/format_pdb_palmdoc.rs
@@ -19,8 +19,13 @@ fn read_database_full() {
 	// TODO: get "sort info" section
 
 	// Test record iteration
-	for (_idx, (rec_hdr, rec_data)) in (0..).zip(database.records.iter()) {
+	for (_idx, (rec_hdr, rec_data)) in database.records.iter().enumerate() {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
 		assert!(rec_hdr.attributes().unwrap_or(0) & 0x40 != 0);
 	}
+
+	let bytes = database.to_bytes().unwrap();
+
+	assert_eq!(bytes.len(), EXAMPLE_PDB.len());
+	assert_eq!(&EXAMPLE_PDB, &bytes);
 }

--- a/palmrs-database/tests/format_pdb_tododb.rs
+++ b/palmrs-database/tests/format_pdb_tododb.rs
@@ -34,8 +34,13 @@ fn read_database_full() {
 	}
 
 	// Test record iteration
-	for (_idx, (rec_hdr, rec_data)) in (0..).zip(database.records.iter()) {
+	for (_idx, (rec_hdr, rec_data)) in database.records.iter().enumerate() {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
 		assert!(rec_hdr.attributes().unwrap_or(0) & 0x40 != 0);
 	}
+
+	let bytes = database.to_bytes().unwrap();
+
+	assert_eq!(bytes.len(), EXAMPLE_PDB.len());
+	assert_eq!(&EXAMPLE_PDB, &bytes);
 }

--- a/palmrs-database/tests/format_prc.rs
+++ b/palmrs-database/tests/format_prc.rs
@@ -7,14 +7,26 @@ const EXAMPLE_PRC: &'static [u8] = include_bytes!("../../test-data/hello-v1.prc"
 fn read_header() {
 	let header = DatabaseHeader::from_bytes(&EXAMPLE_PRC).unwrap();
 	assert_eq!(header.name_try_str().unwrap(), "Hello, World");
+	assert_eq!(
+		&EXAMPLE_PRC[..DatabaseHeader::SIZE],
+		&header.to_bytes().unwrap()
+	);
+	assert_eq!(
+		header,
+		DatabaseHeader::from_bytes(&header.to_bytes().unwrap()).unwrap()
+	);
 }
 
 #[test]
 fn read_database_full() {
 	let database = PalmDatabase::<PrcDatabase>::from_bytes(&EXAMPLE_PRC).unwrap();
-
 	// Test record iteration
 	for (_idx, (rec_hdr, rec_data)) in (0..).zip(database.records.iter()) {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
 	}
+
+	let bytes = database.to_bytes().unwrap();
+
+	assert_eq!(bytes.len(), EXAMPLE_PRC.len());
+	assert_eq!(&EXAMPLE_PRC, &bytes);
 }


### PR DESCRIPTION
Tiny bit of cleanup, and lots of changes to the serialization and deserialization code with tests to match. Can now load and then output a byte-for-byte matching pdb/prc for all the examples already in the repo.