### PR TITLE
Add records/resources to a pdb/prc

### DIFF
--- a/palmrs-database/src/format.rs
+++ b/palmrs-database/src/format.rs
@@ -4,19 +4,21 @@ use core::{
 	fmt::{self, Debug, Display},
 	marker::PhantomData,
 };
-use std::io::{self, Cursor, Write};
+use std::io::{self, Cursor, Read, Write};
 
 use crate::{
-	header::{DatabaseHeader, DATABASE_HEADER_LENGTH},
+	header::DatabaseHeader,
 	info::{category::AppInfoCategories, ExtraInfoRecord, NullExtraInfo},
-	record::{pdb_record::PdbRecordHeader, DatabaseRecord},
+	record::{pdb_record::PdbRecordHeader, DatabaseRecord, DatabaseRecordHelpers},
 };
 
 // add 2 bytes of padding for < os3.5 compatible PRCs
-const COMPAT_PADDING: usize = 2;
+const COMPAT_PADDING_LEN: usize = 2;
 
 /// Helper trait for database format types
 pub trait DatabaseFormat {
+	const USES_COMPAT_PADDING: bool;
+
 	/// The record header type for this database format
 	type RecordHeader: DatabaseRecord;
 
@@ -30,6 +32,7 @@ pub trait DatabaseFormat {
 /// Implementation of [`DatabaseFormat`] for PRC databases
 pub struct PrcDatabase;
 impl DatabaseFormat for PrcDatabase {
+	const USES_COMPAT_PADDING: bool = false;
 	type RecordHeader = PdbRecordHeader;
 	type AppInfoRecord = NullExtraInfo;
 
@@ -45,6 +48,7 @@ impl DatabaseFormat for PrcDatabase {
 /// Implementation of [`DatabaseFormat`] for PDB databases
 pub struct PdbDatabase;
 impl DatabaseFormat for PdbDatabase {
+	const USES_COMPAT_PADDING: bool = false;
 	type RecordHeader = PdbRecordHeader;
 	type AppInfoRecord = NullExtraInfo;
 
@@ -60,6 +64,7 @@ impl DatabaseFormat for PdbDatabase {
 /// Implementation of [`DatabaseFormat`] for PDB databases that contain category information
 pub struct PdbWithCategoriesDatabase;
 impl DatabaseFormat for PdbWithCategoriesDatabase {
+	const USES_COMPAT_PADDING: bool = true;
 	type RecordHeader = PdbRecordHeader;
 	type AppInfoRecord = AppInfoCategories;
 
@@ -80,15 +85,21 @@ impl DatabaseFormat for PdbWithCategoriesDatabase {
 pub struct PalmDatabase<'a, T: DatabaseFormat> {
 	pub header: DatabaseHeader,
 	pub app_info: T::AppInfoRecord,
+
+	/// Also called sortInfo
 	application_reserved: Vec<u8>,
-	pub records: Vec<(T::RecordHeader, Vec<u8>)>,
+
+	/// record headers together with their contained data. This is for convenience,
+	/// and does not match the on-disk layout
+	records: Vec<(T::RecordHeader, Vec<u8>)>,
 	pub(crate) original_data: &'a [u8],
 	_marker: PhantomData<T>,
 }
 
 impl<'a, T: DatabaseFormat> PalmDatabase<'a, T> {
 	pub fn from_bytes(data: &'a [u8]) -> Result<Self, io::Error> {
-		let header = DatabaseHeader::from_bytes(&data)?;
+		let mut rdr = Cursor::new(data);
+		let header = DatabaseHeader::from_bytes(&mut rdr)?;
 
 		if !T::is_valid(&data, &header) {
 			return Err(io::Error::new(
@@ -97,37 +108,40 @@ impl<'a, T: DatabaseFormat> PalmDatabase<'a, T> {
 			));
 		}
 
-		let app_info = T::AppInfoRecord::from_bytes(&header, &data, header.app_info_id as usize)?;
-
-		let mut rec_offset: usize = DATABASE_HEADER_LENGTH;
-		let mut records: Vec<(T::RecordHeader, Vec<u8>)> = Vec::new();
+		let mut record_headers: Vec<T::RecordHeader> = Vec::new();
 		for _idx in 0..header.record_count {
 			// parse record header
-			let record = T::RecordHeader::from_bytes(&header, &data, rec_offset)?;
+			let record = T::RecordHeader::from_bytes(&header, &mut rdr)?;
 
-			// get record data
-			let data_offset = record.data_offset() as usize;
-			let data_len = record.data_len().unwrap_or(0) as usize;
-			let record_data = Vec::from(&data[data_offset..(data_offset + data_len)]);
-
-			// offset & store
-			rec_offset += record.struct_len();
-			records.push((record, record_data));
+			// store
+			record_headers.push(record);
 		}
 
+		if T::USES_COMPAT_PADDING {
+			rdr.read_exact(&mut [0_u8; COMPAT_PADDING_LEN])?;
+		}
+
+		let app_info = T::AppInfoRecord::from_bytes(&header, &mut rdr)?;
+
 		let application_reserved: Vec<u8>;
-		if (header.record_count > 0)
-			&& ((records[0].0.data_offset() as usize)
-				> rec_offset + T::AppInfoRecord::SIZE + COMPAT_PADDING)
-		{
-			let first_record_data_start = records[0].0.data_offset() as usize;
-			application_reserved = Vec::from(
-				&data[(rec_offset + T::AppInfoRecord::SIZE + COMPAT_PADDING)
-					..(first_record_data_start)],
-			)
+		let app_info_end = rdr.position() as usize;
+		let first_record_data_start = record_headers[0].data_offset() as usize;
+		if (header.record_count > 0) && (first_record_data_start > app_info_end) {
+			let mut buf = vec![0_u8; first_record_data_start - app_info_end];
+			rdr.read_exact(&mut buf)?;
+			application_reserved = buf;
 		} else {
 			application_reserved = Vec::new()
 		};
+
+		let mut records: Vec<(T::RecordHeader, Vec<u8>)> = Vec::new();
+		for record_header in record_headers {
+			let record_data_start = record_header.data_offset();
+			let record_data_end = record_data_start + record_header.data_len().unwrap_or(0);
+			let mut record_data = vec![0_u8; (record_data_end - record_data_start) as usize];
+			rdr.read_exact(&mut record_data)?;
+			records.push((record_header, record_data));
+		}
 
 		Ok(Self {
 			header,
@@ -147,7 +161,9 @@ impl<'a, T: DatabaseFormat> PalmDatabase<'a, T> {
 			cursor.write(&record_header.to_bytes()?)?;
 		}
 
-		cursor.write(&[0_u8; COMPAT_PADDING])?;
+		if T::USES_COMPAT_PADDING {
+			cursor.write(&[0_u8; COMPAT_PADDING_LEN])?;
+		}
 
 		cursor.write(&self.app_info.to_bytes()?)?;
 
@@ -160,6 +176,18 @@ impl<'a, T: DatabaseFormat> PalmDatabase<'a, T> {
 
 		Ok(cursor.into_inner())
 	}
+
+	pub fn list_records_resources(&self) -> &[(T::RecordHeader, Vec<u8>)] {
+		&self.records
+	}
+
+	pub fn insert_record() {}
+
+	pub fn insert_resource() {}
+
+	pub fn remove_record() {}
+
+	pub fn remove_resources() {}
 }
 
 impl<'a, T: DatabaseFormat> Debug for PalmDatabase<'a, T> {

--- a/palmrs-database/src/header.rs
+++ b/palmrs-database/src/header.rs
@@ -39,9 +39,7 @@ impl DatabaseHeader {
 	pub const SIZE: usize = DATABASE_HEADER_LENGTH;
 
 	/// Read the database header from the given byte slice.
-	pub fn from_bytes(data: &[u8]) -> Result<Self, io::Error> {
-		let mut rdr = Cursor::new(&data[..DATABASE_HEADER_LENGTH]);
-
+	pub fn from_bytes(rdr: &mut Cursor<&[u8]>) -> Result<Self, io::Error> {
 		// Read all the data
 
 		let name = {

--- a/palmrs-database/src/header.rs
+++ b/palmrs-database/src/header.rs
@@ -17,7 +17,6 @@ pub const DATABASE_HEADER_LENGTH: usize = 78;
 ///
 /// This is located at the start of the database (offset `0`).
 #[derive(Debug, Copy, Clone, PartialEq)]
-#[repr(C, packed)]
 pub struct DatabaseHeader {
 	pub name: [u8; 32],
 	pub attributes: u16,
@@ -95,7 +94,7 @@ impl DatabaseHeader {
 		Ok(created_header)
 	}
 
-	pub fn to_bytes(self) -> std::io::Result<Vec<u8>> {
+	pub fn to_bytes(&self) -> std::io::Result<Vec<u8>> {
 		let mut cursor = Cursor::new(vec![0_u8; Self::SIZE]);
 
 		let DatabaseHeader {
@@ -115,20 +114,20 @@ impl DatabaseHeader {
 			record_count,
 		} = self;
 
-		cursor.write(&name)?;
-		cursor.write_u16::<BigEndian>(attributes)?;
-		cursor.write_u16::<BigEndian>(version)?;
+		cursor.write(name)?;
+		cursor.write_u16::<BigEndian>(*attributes)?;
+		cursor.write_u16::<BigEndian>(*version)?;
 		cursor.write_u32::<BigEndian>(creation_time.0)?;
 		cursor.write_u32::<BigEndian>(modification_time.0)?;
 		cursor.write_u32::<BigEndian>(backup_time.0)?;
-		cursor.write_u32::<BigEndian>(modification_number)?;
-		cursor.write_u32::<BigEndian>(app_info_id)?;
-		cursor.write_u32::<BigEndian>(sort_info_id)?;
-		cursor.write(&type_code)?;
-		cursor.write(&creator_code)?;
-		cursor.write_u32::<BigEndian>(unique_id_seed)?;
-		cursor.write_u32::<BigEndian>(next_record_list)?;
-		cursor.write_u16::<BigEndian>(record_count)?;
+		cursor.write_u32::<BigEndian>(*modification_number)?;
+		cursor.write_u32::<BigEndian>(*app_info_id)?;
+		cursor.write_u32::<BigEndian>(*sort_info_id)?;
+		cursor.write(type_code)?;
+		cursor.write(creator_code)?;
+		cursor.write_u32::<BigEndian>(*unique_id_seed)?;
+		cursor.write_u32::<BigEndian>(*next_record_list)?;
+		cursor.write_u16::<BigEndian>(*record_count)?;
 
 		Ok(cursor.into_inner())
 	}

--- a/palmrs-database/src/info/category.rs
+++ b/palmrs-database/src/info/category.rs
@@ -9,14 +9,6 @@ use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
 use crate::{header::DatabaseHeader, info::ExtraInfoRecord};
 
-/// Item record category bitmask
-///
-/// Using the value of this constant as a bitmask on the `attributes` field of a
-/// [`PdbRecordHeader::Record`][crate::record::pdb_record::PdbRecordHeader::Record] will give you
-/// the category ID as an integer in the range `0..15`.
-#[allow(unused_variables)]
-pub const CATEGORY_ATTRIBUTE_MASK: u8 = 0x0F;
-
 /// Representation of an item category
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct ExtraInfoCategory {

--- a/palmrs-database/src/info/category.rs
+++ b/palmrs-database/src/info/category.rs
@@ -3,7 +3,7 @@
 //! Item category record helpers
 
 use core::{fmt::Debug, str};
-use std::io::{self, Cursor, Read, Seek, SeekFrom, Write};
+use std::io::{self, Cursor, Read, Write};
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 
@@ -75,14 +75,11 @@ pub struct AppInfoCategories {
 }
 
 impl AppInfoCategories {
-	pub fn from_bytes(hdr: &DatabaseHeader, data: &[u8], pos: usize) -> Result<Self, io::Error> {
+	pub fn from_bytes(hdr: &DatabaseHeader, rdr: &mut Cursor<&[u8]>) -> Result<Self, io::Error> {
 		// Do a quick check by type/creator codes for whether we should actually have categories
 		if &hdr.type_code[..] != b"DATA" {
 			return Ok(Default::default());
 		}
-
-		let mut rdr = Cursor::new(&data);
-		rdr.seek(SeekFrom::Start(pos as u64))?;
 
 		let mut categories = Vec::new();
 		let renamed_flags = rdr.read_u16::<BigEndian>()?;
@@ -126,8 +123,8 @@ impl AppInfoCategories {
 impl ExtraInfoRecord for AppInfoCategories {
 	const SIZE: usize = 2 + 16 * 16 + 16 + 1 + 1;
 
-	fn from_bytes(hdr: &DatabaseHeader, data: &[u8], pos: usize) -> Result<Self, io::Error> {
-		Self::from_bytes(hdr, data, pos)
+	fn from_bytes(hdr: &DatabaseHeader, data: &mut Cursor<&[u8]>) -> Result<Self, io::Error> {
+		Self::from_bytes(hdr, data)
 	}
 
 	fn to_bytes(&self) -> Result<Vec<u8>, io::Error> {

--- a/palmrs-database/src/info/mod.rs
+++ b/palmrs-database/src/info/mod.rs
@@ -1,7 +1,7 @@
 //! App info & sort info parsers and helpers
 
 use core::fmt::Debug;
-use std::io;
+use std::io::{self, Cursor};
 
 use crate::header::DatabaseHeader;
 
@@ -13,7 +13,7 @@ pub trait ExtraInfoRecord: Sized + Debug {
 	const SIZE: usize;
 
 	/// Read the record header from the given byte array
-	fn from_bytes(hdr: &DatabaseHeader, data: &[u8], pos: usize) -> Result<Self, io::Error>;
+	fn from_bytes(hdr: &DatabaseHeader, data: &mut Cursor<&[u8]>) -> Result<Self, io::Error>;
 
 	/// Write the record header to a new `Vec<u8>`
 	fn to_bytes(&self) -> Result<Vec<u8>, io::Error>;
@@ -33,7 +33,7 @@ pub struct NullExtraInfo;
 impl ExtraInfoRecord for NullExtraInfo {
 	const SIZE: usize = 0;
 
-	fn from_bytes(_hdr: &DatabaseHeader, _data: &[u8], _pos: usize) -> Result<Self, io::Error> {
+	fn from_bytes(_hdr: &DatabaseHeader, _data: &mut Cursor<&[u8]>) -> Result<Self, io::Error> {
 		Ok(Self)
 	}
 

--- a/palmrs-database/src/record/mod.rs
+++ b/palmrs-database/src/record/mod.rs
@@ -5,19 +5,16 @@
 //! for PDB/PRC record and resource header types.
 
 use core::fmt::Debug;
-use std::io;
+use std::io::{self, Cursor};
 
 use crate::header::DatabaseHeader;
 
 pub mod pdb_record;
 
 /// Helper trait for database record types
-pub trait DatabaseRecord: Sized + Debug {
-	/// The length of the record header, in bytes
-	fn struct_len(&self) -> usize;
-
+pub trait DatabaseRecord: Sized + Debug + sealed::DatabaseRecordHelpers {
 	/// Read the record header from the given byte array
-	fn from_bytes(hdr: &DatabaseHeader, data: &[u8], pos: usize) -> Result<Self, io::Error>;
+	fn from_bytes(hdr: &DatabaseHeader, rdr: &mut Cursor<&[u8]>) -> Result<Self, io::Error>;
 
 	/// Write the record header to a new `Vec<u8>`
 	fn to_bytes(&self) -> Result<Vec<u8>, io::Error>;
@@ -28,9 +25,20 @@ pub trait DatabaseRecord: Sized + Debug {
 	/// Return the record's attributes, if known
 	fn attributes(&self) -> Option<u32>;
 
-	/// Return the offset, from the start of the database file, of the record's data
-	fn data_offset(&self) -> u32;
-
 	/// Return the length of the record's data, if known
 	fn data_len(&self) -> Option<u32>;
 }
+
+mod sealed {
+
+	pub trait DatabaseRecordHelpers {
+		/// The length of the record header, in bytes
+		fn struct_len(&self) -> usize;
+
+		fn next_entry_data_offset(&self) -> usize;
+
+		fn data_offset(&self) -> u32;
+	}
+}
+
+pub(crate) use sealed::DatabaseRecordHelpers;

--- a/palmrs-database/src/record/mod.rs
+++ b/palmrs-database/src/record/mod.rs
@@ -23,10 +23,32 @@ pub trait DatabaseRecord: Sized + Debug + sealed::DatabaseRecordHelpers {
 	fn name_str(&self) -> Option<&str>;
 
 	/// Return the record's attributes, if known
-	fn attributes(&self) -> Option<u32>;
+	fn attributes(&self) -> Option<RecordAttributes>;
 
 	/// Return the length of the record's data, if known
 	fn data_len(&self) -> Option<u32>;
+
+	/// Return the unique id if the record is not a resource
+	fn unique_id(&self) -> Option<u32>;
+
+	/// Return the resource id if the record is a resource
+	fn resource_id(&self) -> Option<u16>;
+
+	/// Construct a record with the given parameters
+	fn construct_record(
+		attributes: RecordAttributes,
+		unique_id: u32,
+		data_offset: u32,
+		data_len: Option<u32>,
+	) -> Self;
+
+	/// Construct a resource with the given parameters
+	fn construct_resource(
+		name: &[u8; 4],
+		record_id: u16,
+		data_offset: u32,
+		data_len: Option<u32>,
+	) -> Self;
 }
 
 mod sealed {
@@ -42,3 +64,5 @@ mod sealed {
 }
 
 pub(crate) use sealed::DatabaseRecordHelpers;
+
+use self::pdb_record::RecordAttributes;

--- a/palmrs-database/tests/add_resources.rs
+++ b/palmrs-database/tests/add_resources.rs
@@ -1,0 +1,59 @@
+use palmrs_database::{
+	record::{
+		pdb_record::{PdbRecordHeader, RecordAttributes},
+		DatabaseRecord,
+	},
+	DatabaseFormat,
+	PalmDatabase,
+	PdbDatabase,
+	PdbWithCategoriesDatabase,
+	PrcDatabase,
+};
+
+const EXAMPLE_PRC: &'static [u8] = include_bytes!("../../test-data/hello-v1.prc");
+const EXAMPLE_PDB: &'static [u8] = include_bytes!("../../test-data/ToDoDB.pdb");
+const MANUAL_PDB: &'static [u8] = include_bytes!("../../test-data/tWmanual.pdb");
+
+fn test_db<T: DatabaseFormat>(src_bytes: &'static [u8])
+where
+	<T as DatabaseFormat>::RecordHeader: PartialEq<PdbRecordHeader>,
+{
+	let mut database = PalmDatabase::<T>::from_bytes(src_bytes).unwrap();
+
+	let test_str = "sphinx of black quartz, judge my vow";
+
+	// test adding a record
+	let record_id = database.insert_record(RecordAttributes::default(), test_str.as_bytes());
+	let (_, recovered_data) = database
+		.list_records_resources()
+		.into_iter()
+		.find(|(hdr, _)| hdr.unique_id() == Some(record_id))
+		.unwrap();
+	assert_eq!(
+		String::from_utf8(recovered_data.to_vec()).unwrap(),
+		test_str
+	);
+
+	// test adding a resource
+	let mut test_name: [u8; 4] = [0_u8; 4];
+	test_name[0..4].copy_from_slice("test".as_bytes());
+	let resource_id = database.insert_resource(&test_name, test_str.as_bytes());
+	let (hdr, recovered_data) = database
+		.list_records_resources()
+		.into_iter()
+		.find(|(hdr, _)| hdr.resource_id() == Some(resource_id))
+		.unwrap();
+	assert_eq!(
+		String::from_utf8(recovered_data.to_vec()).unwrap(),
+		test_str
+	);
+
+	assert_eq!(hdr.name_str().map(str::as_bytes).unwrap(), test_name);
+}
+
+#[test]
+fn test_records_all_db_types() {
+	test_db::<PrcDatabase>(&EXAMPLE_PRC);
+	test_db::<PdbDatabase>(&MANUAL_PDB);
+	test_db::<PdbWithCategoriesDatabase>(&EXAMPLE_PDB);
+}

--- a/palmrs-database/tests/format_pdb_palmdoc.rs
+++ b/palmrs-database/tests/format_pdb_palmdoc.rs
@@ -23,7 +23,7 @@ fn read_database_full() {
 	// Test record iteration
 	for (_idx, (rec_hdr, rec_data)) in database.list_records_resources().iter().enumerate() {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
-		assert!(rec_hdr.attributes().unwrap_or(0) & 0x40 != 0);
+		assert!(rec_hdr.attributes().unwrap_or_default().dirty);
 	}
 
 	let bytes = database.to_bytes().unwrap();

--- a/palmrs-database/tests/format_pdb_palmdoc.rs
+++ b/palmrs-database/tests/format_pdb_palmdoc.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use palmrs_database::{header::DatabaseHeader, record::DatabaseRecord, PalmDatabase, PdbDatabase};
 use test_env_log::test;
 
@@ -5,7 +7,7 @@ const EXAMPLE_PDB: &'static [u8] = include_bytes!("../../test-data/tWmanual.pdb"
 
 #[test]
 fn read_header() {
-	let header = DatabaseHeader::from_bytes(&EXAMPLE_PDB).unwrap();
+	let header = DatabaseHeader::from_bytes(&mut Cursor::new(&EXAMPLE_PDB)).unwrap();
 	assert_eq!(header.name_try_str().unwrap(), "tWmanual");
 	assert_eq!(header.type_code_try_str().unwrap(), "TEXt");
 	assert_eq!(header.creator_code_try_str().unwrap(), "REAd");
@@ -19,7 +21,7 @@ fn read_database_full() {
 	// TODO: get "sort info" section
 
 	// Test record iteration
-	for (_idx, (rec_hdr, rec_data)) in database.records.iter().enumerate() {
+	for (_idx, (rec_hdr, rec_data)) in database.list_records_resources().iter().enumerate() {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
 		assert!(rec_hdr.attributes().unwrap_or(0) & 0x40 != 0);
 	}

--- a/palmrs-database/tests/format_pdb_tododb.rs
+++ b/palmrs-database/tests/format_pdb_tododb.rs
@@ -38,7 +38,7 @@ fn read_database_full() {
 	// Test record iteration
 	for (_idx, (rec_hdr, rec_data)) in database.list_records_resources().iter().enumerate() {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
-		assert!(rec_hdr.attributes().unwrap_or(0) & 0x40 != 0);
+		assert!(rec_hdr.attributes().unwrap_or_default().dirty);
 	}
 
 	let bytes = database.to_bytes().unwrap();

--- a/palmrs-database/tests/format_pdb_tododb.rs
+++ b/palmrs-database/tests/format_pdb_tododb.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use palmrs_database::{
 	header::DatabaseHeader,
 	info::ExtraInfoRecord,
@@ -11,7 +13,7 @@ const EXAMPLE_PDB: &'static [u8] = include_bytes!("../../test-data/ToDoDB.pdb");
 
 #[test]
 fn read_header() {
-	let header = DatabaseHeader::from_bytes(&EXAMPLE_PDB).unwrap();
+	let header = DatabaseHeader::from_bytes(&mut Cursor::new(&EXAMPLE_PDB)).unwrap();
 	assert_eq!(header.name_try_str().unwrap(), "ToDoDB");
 	assert_eq!(header.type_code_try_str().unwrap(), "DATA");
 	assert_eq!(header.creator_code_try_str().unwrap(), "todo");
@@ -34,7 +36,7 @@ fn read_database_full() {
 	}
 
 	// Test record iteration
-	for (_idx, (rec_hdr, rec_data)) in database.records.iter().enumerate() {
+	for (_idx, (rec_hdr, rec_data)) in database.list_records_resources().iter().enumerate() {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
 		assert!(rec_hdr.attributes().unwrap_or(0) & 0x40 != 0);
 	}

--- a/palmrs-database/tests/format_prc.rs
+++ b/palmrs-database/tests/format_prc.rs
@@ -1,3 +1,5 @@
+use std::io::Cursor;
+
 use palmrs_database::{header::DatabaseHeader, record::DatabaseRecord, PalmDatabase, PrcDatabase};
 use test_env_log::test;
 
@@ -5,7 +7,7 @@ const EXAMPLE_PRC: &'static [u8] = include_bytes!("../../test-data/hello-v1.prc"
 
 #[test]
 fn read_header() {
-	let header = DatabaseHeader::from_bytes(&EXAMPLE_PRC).unwrap();
+	let header = DatabaseHeader::from_bytes(&mut Cursor::new(&EXAMPLE_PRC)).unwrap();
 	assert_eq!(header.name_try_str().unwrap(), "Hello, World");
 	assert_eq!(
 		&EXAMPLE_PRC[..DatabaseHeader::SIZE],
@@ -13,7 +15,7 @@ fn read_header() {
 	);
 	assert_eq!(
 		header,
-		DatabaseHeader::from_bytes(&header.to_bytes().unwrap()).unwrap()
+		DatabaseHeader::from_bytes(&mut Cursor::new(&header.to_bytes().unwrap())).unwrap()
 	);
 }
 
@@ -21,7 +23,7 @@ fn read_header() {
 fn read_database_full() {
 	let database = PalmDatabase::<PrcDatabase>::from_bytes(&EXAMPLE_PRC).unwrap();
 	// Test record iteration
-	for (_idx, (rec_hdr, rec_data)) in (0..).zip(database.records.iter()) {
+	for (_idx, (rec_hdr, rec_data)) in (0..).zip(database.list_records_resources().iter()) {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);
 	}
 

--- a/palmrs-database/tests/format_prc.rs
+++ b/palmrs-database/tests/format_prc.rs
@@ -21,7 +21,7 @@ fn read_header() {
 
 #[test]
 fn read_database_full() {
-	let database = PalmDatabase::<PrcDatabase>::from_bytes(&EXAMPLE_PRC).unwrap();
+	let database = dbg!(PalmDatabase::<PrcDatabase>::from_bytes(&EXAMPLE_PRC).unwrap());
 	// Test record iteration
 	for (_idx, (rec_hdr, rec_data)) in (0..).zip(database.list_records_resources().iter()) {
 		assert_eq!(rec_data.len(), rec_hdr.data_len().unwrap_or(0) as usize);

--- a/src/bin/conduit_todotxt.rs
+++ b/src/bin/conduit_todotxt.rs
@@ -10,7 +10,7 @@ use std::{
 use byteorder::{BigEndian, ReadBytesExt};
 use palmrs::{
 	database::{
-		info::{category::CATEGORY_ATTRIBUTE_MASK, ExtraInfoRecord},
+		info::ExtraInfoRecord,
 		record::DatabaseRecord,
 		PalmDatabase,
 		PdbWithCategoriesDatabase,
@@ -106,17 +106,19 @@ pub fn device_database_parse(db_path: &Path) -> Result<Vec<ToDoTask>, Report> {
 	};
 
 	let mut tasks = Vec::new();
-	'dbtaskparse: for (idx, (rec_hdr, rec_data)) in (0..).zip(database.list_records_resources().iter()) {
+	'dbtaskparse: for (idx, (rec_hdr, rec_data)) in
+		(0..).zip(database.list_records_resources().iter())
+	{
 		log::trace!("records[{}].rec_hdr = {:?}", idx, &rec_hdr);
 		if rec_hdr.data_len().unwrap_or(0) == 0 {
 			break 'dbtaskparse;
 		}
 
 		// Get category from record attributes
-		let rec_attributes = rec_hdr.attributes().unwrap_or(0u32);
+		let rec_attributes = rec_hdr.attributes().unwrap_or_default();
 		let category = {
 			let mut catname: Option<String> = None;
-			let catid = ((rec_attributes & 0xFF) as u8) & CATEGORY_ATTRIBUTE_MASK;
+			let catid = rec_attributes.category;
 			'catsearch: for (x_catid, x_catname) in categories.iter() {
 				if catid == *x_catid {
 					catname = Some(x_catname.clone());

--- a/src/bin/conduit_todotxt.rs
+++ b/src/bin/conduit_todotxt.rs
@@ -106,7 +106,7 @@ pub fn device_database_parse(db_path: &Path) -> Result<Vec<ToDoTask>, Report> {
 	};
 
 	let mut tasks = Vec::new();
-	'dbtaskparse: for (idx, (rec_hdr, rec_data)) in (0..).zip(database.records.iter()) {
+	'dbtaskparse: for (idx, (rec_hdr, rec_data)) in (0..).zip(database.list_records_resources().iter()) {
 		log::trace!("records[{}].rec_hdr = {:?}", idx, &rec_hdr);
 		if rec_hdr.data_len().unwrap_or(0) == 0 {
 			break 'dbtaskparse;

--- a/src/bin/db_dump.rs
+++ b/src/bin/db_dump.rs
@@ -165,7 +165,7 @@ fn perform_dump<T: DatabaseFormat>(data: &[u8], opt: &Opt) -> Result<(), Report>
 	perform_dump_header(&database.header)?;
 
 	// Dump each record, additionally dumping app info before the first record
-	for (idx, (rec_hdr, rec_data)) in (0..).zip(database.records.iter()) {
+	for (idx, (rec_hdr, rec_data)) in (0..).zip(database.list_records_resources().iter()) {
 		if idx == 0 {
 			perform_dump_app_info(&database.header, &database.app_info, rec_hdr, &data, &opt)?;
 		}

--- a/src/bin/db_dump.rs
+++ b/src/bin/db_dump.rs
@@ -129,7 +129,7 @@ where
 
 	let data_offset = rec_hdr.data_offset() as usize;
 	let data_len = rec_hdr.data_len().map(|x| x as usize).unwrap_or(0usize);
-	let attributes = rec_hdr.attributes().unwrap_or(0);
+	let attributes = rec_hdr.attributes().unwrap_or_default();
 
 	println!(
 		"Record {}: name={:?} offset={:#X} length={:#X} attributes={:#X}",
@@ -137,7 +137,7 @@ where
 		rec_hdr.name_str().unwrap_or(""),
 		data_offset,
 		data_len,
-		attributes,
+		u8::from(attributes),
 	);
 
 	if opt.hexdump_records {

--- a/src/bin/sync_dbgconduit.rs
+++ b/src/bin/sync_dbgconduit.rs
@@ -10,6 +10,7 @@ use subprocess::Redirection;
 #[structopt(name = "palmrs-sync-dbgconduit")]
 struct Opt {
 	/// Path to sync configuration
+	#[allow(unused)]
 	#[structopt(short, long)]
 	config: Option<PathBuf>,
 


### PR DESCRIPTION
Adds an abstraction over resource attributes which hides the bit manipulation, and adds the ability to insert resources or records (no removal yet). Also fixes a couple bugs related to the compatibility padding between PalmOS versions, and uses cursors more places internally to reduce the amount of required offset tracking.